### PR TITLE
Switch from black to ruff format

### DIFF
--- a/.github/bump_version.py
+++ b/.github/bump_version.py
@@ -19,9 +19,7 @@ def get_current_version(pyproject_path: Path) -> str:
 
 def infer_bump(changelog_dir: Path) -> str:
     fragments = [
-        f
-        for f in changelog_dir.iterdir()
-        if f.is_file() and f.name != ".gitkeep"
+        f for f in changelog_dir.iterdir() if f.is_file() and f.name != ".gitkeep"
     ]
     if not fragments:
         print("No changelog fragments found", file=sys.stderr)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install ruff
+        run: pip install ruff
       - name: Check formatting
-        uses: "lgeiger/black-action@master"
-        with:
-          args: ". -l 79 --check"
+        run: ruff format --check .
   check-changelog:
     name: Check changelog fragment
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,10 +10,10 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine Israel')
     steps:
       - uses: actions/checkout@v4
+      - name: Install ruff
+        run: pip install ruff
       - name: Check formatting
-        uses: "lgeiger/black-action@master"
-        with:
-          args: ". -l 79 --check"
+        run: ruff format --check .
   versioning:
     name: Update versioning
     if: |

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ documentation:
 	myst build docs
 
 format:
-	black . -l 79
+	ruff format .
 
 install:
 	pip install -e .[dev]

--- a/changelog.d/switch-to-ruff.changed.md
+++ b/changelog.d/switch-to-ruff.changed.md
@@ -1,0 +1,1 @@
+Switch from black to ruff format.

--- a/policyengine_il/variables/gov/low_income_municipal_tax_reduction/max_low_income_municipal_tax_reduction.py
+++ b/policyengine_il/variables/gov/low_income_municipal_tax_reduction/max_low_income_municipal_tax_reduction.py
@@ -3,9 +3,7 @@ from policyengine_il.model_api import *
 
 class max_low_income_municipal_tax_reduction(Variable):
     label = "Maximum low-income municipal tax reduction"
-    documentation = (
-        "Municipalities can reduce municipal tax by up to this amount"
-    )
+    documentation = "Municipalities can reduce municipal tax by up to this amount"
     entity = Household
     definition_period = YEAR
     value_type = float

--- a/policyengine_il/variables/gov/low_income_municipal_tax_reduction/max_low_income_municipal_tax_reduction_rate.py
+++ b/policyengine_il/variables/gov/low_income_municipal_tax_reduction/max_low_income_municipal_tax_reduction_rate.py
@@ -3,9 +3,7 @@ from policyengine_il.model_api import *
 
 class max_low_income_municipal_tax_reduction_rate(Variable):
     label = "Maximum low-income municipal tax reduction rate"
-    documentation = (
-        "Municipalities can reduce municipal tax by up to this percentage"
-    )
+    documentation = "Municipalities can reduce municipal tax by up to this percentage"
     entity = Household
     definition_period = YEAR
     value_type = float
@@ -14,16 +12,14 @@ class max_low_income_municipal_tax_reduction_rate(Variable):
 
     def formula(household, period, parameters):
         params = parameters(period).gov.low_income_municipal_tax_reduction_rate
-        annual_income = household(
-            "low_income_municipal_tax_reduction_income", period
-        )
+        annual_income = household("low_income_municipal_tax_reduction_income", period)
         monthly_income = annual_income / MONTHS_IN_YEAR
         household_size = household("household_size", period)
         rates = np.zeros_like(monthly_income)
         for possible_household_size in range(1, 10):
-            applicable_rate = getattr(
-                params, str(possible_household_size)
-            ).calc(monthly_income, right=True)
+            applicable_rate = getattr(params, str(possible_household_size)).calc(
+                monthly_income, right=True
+            )
             rates = where(
                 household_size == possible_household_size,
                 applicable_rate,

--- a/policyengine_il/variables/marginal_tax_rate.py
+++ b/policyengine_il/variables/marginal_tax_rate.py
@@ -13,13 +13,9 @@ class marginal_tax_rate(Variable):
         simulation = person.simulation
         adult_index_values = person("adult_index", period)
         DELTA = 1_000
-        mtr_adult_count = parameters(
-            period
-        ).simulation.marginal_tax_rate_adults
+        mtr_adult_count = parameters(period).simulation.marginal_tax_rate_adults
         for adult_index in range(1, 1 + mtr_adult_count):
-            alt_simulation = simulation.get_branch(
-                f"adult_{adult_index}_pay_rise"
-            )
+            alt_simulation = simulation.get_branch(f"adult_{adult_index}_pay_rise")
             mask = adult_index_values == adult_index
             for variable in simulation.tax_benefit_system.variables:
                 if variable not in simulation.input_variables:
@@ -30,15 +26,11 @@ class marginal_tax_rate(Variable):
                 person("employment_income", period) + mask * DELTA,
             )
             alt_person = alt_simulation.person
-            household_net_income = person.household(
-                "household_net_income", period
-            )
+            household_net_income = person.household("household_net_income", period)
             household_net_income_higher_earnings = alt_person.household(
                 "household_net_income", period
             )
-            increase = (
-                household_net_income_higher_earnings - household_net_income
-            )
+            increase = household_net_income_higher_earnings - household_net_income
             mtr_values += where(mask, 1 - increase / DELTA, 0)
             print(household_net_income)
             print(household_net_income_higher_earnings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,13 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black",
     "build",
     "coverage",
     "jupyter-book>=1.0.4",
     "mystmd>=1.3.17",
-    "linecheck",
     "plotly",
     "pytest",
+    "ruff>=0.9.0",
     "setuptools",
     "towncrier>=24.8.0",
     "wheel",


### PR DESCRIPTION
## Summary
- Replace `black` and `linecheck` with `ruff>=0.9.0` in dev dependencies
- Update Makefile to use `ruff format .` instead of `black . -l 79`
- Update CI workflows (pr.yaml, push.yaml) to use `ruff format --check .` instead of the black GitHub action
- Reformat all Python files with ruff defaults (line-length 88)

## Test plan
- [ ] Verify `ruff format --check .` passes in CI
- [ ] Verify existing tests still pass

Generated with [Claude Code](https://claude.com/claude-code)