### PR TITLE
Mint GitHub App token in push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,10 +15,16 @@ jobs:
       && !(github.event.head_commit.message == 'Update PolicyEngine Israel')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -37,6 +43,8 @@ jobs:
           committer_name: Github Actions[bot]
           author_name: Github Actions[bot]
           message: Update PolicyEngine Israel
+          github_token: ${{ steps.app-token.outputs.token }}
+          fetch: false
   Test:
     runs-on: ${{ matrix.os }}
     if: |
@@ -95,13 +103,17 @@ jobs:
       (github.repository == 'PolicyEngine/policyengine-il')
       && (github.event.head_commit.message == 'Update PolicyEngine Israel')
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -113,4 +125,5 @@ jobs:
       - name: Update API
         run: python .github/update_api.py
         env:
-          GITHUB_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/changelog.d/migrate-to-app-token.changed.md
+++ b/changelog.d/migrate-to-app-token.changed.md
@@ -1,0 +1,1 @@
+Mint GitHub App token at runtime in push workflow instead of using the expired org PAT.


### PR DESCRIPTION
## Summary
- Replaces expired `POLICYENGINE_GITHUB` org PAT with a GitHub App token minted at job start via `actions/create-github-app-token@v1`.
- Covers both jobs that previously consumed the PAT: `versioning` (checkout + `EndBug/add-and-commit`) and `Deploy` (checkout + `update_api.py` env).
- Matches the pattern already landed in `policyengine-core` (#470), `microdf` (#296), and sibling country repos (`us`, `ng`, `canada`, `it`).

## Test plan
- [ ] Push CI green on `master` after merge (will be validated here via CI on this PR).
- [ ] `versioning` job's auto-commit succeeds (fetch: false; App token in `EndBug/add-and-commit`).
- [ ] `Deploy` job successfully calls `update_api.py` against policyengine-app with `GH_TOKEN` / `GITHUB_TOKEN` from App token.